### PR TITLE
Initial GraphQL structure

### DIFF
--- a/.github/workflows/dotnet_build_test.yml
+++ b/.github/workflows/dotnet_build_test.yml
@@ -30,3 +30,6 @@ jobs:
 
     - name: Test
       run: dotnet test --no-build --verbosity normal
+
+    - name: Generate GraphQL schema
+      run: dotnet run --project ./src/Backend/Backend.Api/ -- schema export

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Backend/Backend.Api/bin/Debug/net7.0/Backend.Api.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Backend/Backend.Api",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Wotan.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Wotan.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/Wotan.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Backend/Backend.Api/Backend.Api.csproj
+++ b/src/Backend/Backend.Api/Backend.Api.csproj
@@ -6,4 +6,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.5.2" />
+    <PackageReference Include="HotChocolate" Version="13.2.1" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="13.2.1" />
+    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="13.2.1" />
+    <PackageReference Include="HotChocolate.Data" Version="13.2.1" />
+    <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="13.2.1" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Backend/Backend.Api/GraphQL/Extensions/GraphQLConfigurationExtensions.cs
+++ b/src/Backend/Backend.Api/GraphQL/Extensions/GraphQLConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+using HotChocolate.Types.Pagination;
+
+namespace Wotan.Backend.Api.GraphQL.Extensions;
+
+internal static class GraphQLConfigurationExtensions
+{
+    public static WebApplicationBuilder ConfigureGraphQLServer(
+        this WebApplicationBuilder builder)
+    {
+        builder.Services
+            .AddMemoryCache()   // Used by persisted queries
+            .AddGraphQLServer()
+                .InitializeOnStartup()
+                .ModifyRequestOptions(opt =>
+                {
+                    opt.Complexity.Enable = true;
+                    opt.Complexity.MaximumAllowed = 1500;
+                })
+                .SetPagingOptions(new PagingOptions
+                {
+                    DefaultPageSize = 10,
+                    MaxPageSize = 200,
+                    IncludeTotalCount = true
+                })
+                .UseAutomaticPersistedQueryPipeline()
+            .AddInMemoryQueryStorage()
+            .AddGraphQLTypes()
+            .AddFiltering()
+            .AddProjections()
+            .AddSorting();
+
+        return builder;
+    }
+}

--- a/src/Backend/Backend.Api/GraphQL/Query.cs
+++ b/src/Backend/Backend.Api/GraphQL/Query.cs
@@ -1,0 +1,18 @@
+namespace Wotan.Backend.Api.GraphQL;
+
+[QueryType]
+[GraphQLDescription("All supported queries")]
+public class Query
+{
+    public Book GetBook()
+        => new Book(
+            Title: "Some Book title",
+            Year: 1234,
+            Author: new Author(
+                Age: 123,
+                Name: "Some Author name"));
+}
+
+// tmp records used for schema generation
+public record Book(string Title, int Year, Author Author);
+public record Author(int Age, string Name);

--- a/src/Backend/Backend.Api/Program.cs
+++ b/src/Backend/Backend.Api/Program.cs
@@ -1,6 +1,20 @@
+using Wotan.Backend.Api.Settings;
+using Wotan.Backend.Api.GraphQL.Extensions;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder
+    .APIConfigurationSetup()
+    .ConfigureGraphQLServer();
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.UseHttpsRedirection();
+app.MapGraphQL();
 
-app.Run();
+// Only used for heart beats (such as Application Insight)
+app.MapGet("/", () => StatusCodes.Status200OK);
+
+// Used for handling startup parameteres regarding Hotchocolate
+// such as generating a schema without starting the API
+await app.RunWithGraphQLCommandsAsync(args);

--- a/src/Backend/Backend.Api/Properties/ModuleInfo.cs
+++ b/src/Backend/Backend.Api/Properties/ModuleInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Module("GraphQLTypes")]

--- a/src/Backend/Backend.Api/Properties/launchSettings.json
+++ b/src/Backend/Backend.Api/Properties/launchSettings.json
@@ -1,34 +1,10 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:24305",
-      "sslPort": 44310
-    }
-  },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5100",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:7145;http://localhost:5100",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Backend/Backend.Api/Settings/ApiSettings.cs
+++ b/src/Backend/Backend.Api/Settings/ApiSettings.cs
@@ -1,0 +1,4 @@
+namespace Wotan.Backend.Api.Settings;
+
+// TODO: Add configuration properties here
+internal class ApiSettings { }

--- a/src/Backend/Backend.Api/Settings/ApiSettingsValidator.cs
+++ b/src/Backend/Backend.Api/Settings/ApiSettingsValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Wotan.Backend.Api.Settings;
+
+internal class ApiSettingsValidator : AbstractValidator<ApiSettings>
+{
+    public ApiSettingsValidator()
+    {
+        // TODO: Add any settings property validation here
+    }
+}

--- a/src/Backend/Backend.Api/Settings/ConfigurationExtensions.cs
+++ b/src/Backend/Backend.Api/Settings/ConfigurationExtensions.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace Wotan.Backend.Api.Settings;
+
+internal static class ConfigurationExtensions
+{
+    public static WebApplicationBuilder APIConfigurationSetup(
+        this WebApplicationBuilder builder)
+    {
+        builder.Configuration
+            .AddJsonFile("appsettings.json",
+                optional: true,
+                reloadOnChange: true)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json",
+                optional: true,
+                reloadOnChange: true);
+
+        // Validate loaded configuration with custom validator
+        builder.Services.AddScoped<IValidator<ApiSettings>, ApiSettingsValidator>();
+        builder.Services.AddOptions<ApiSettings>()
+            .BindConfiguration(nameof(ApiSettings))
+            .ValidateAPISettings()
+            .ValidateOnStart();
+
+        return builder;
+    }
+}

--- a/src/Backend/Backend.Api/Settings/FluentValidationOptions.cs
+++ b/src/Backend/Backend.Api/Settings/FluentValidationOptions.cs
@@ -1,0 +1,50 @@
+using FluentValidation;
+
+using Microsoft.Extensions.Options;
+
+namespace Wotan.Backend.Api.Settings;
+
+internal class FluentValidationOptions<TOptions> : IValidateOptions<TOptions>
+    where TOptions : class
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly string? _name;
+
+    public FluentValidationOptions(
+        IServiceProvider serviceProvider,
+        string? name)
+    {
+        _serviceProvider = serviceProvider;
+        _name = name;
+    }
+
+    public ValidateOptionsResult Validate(string? name, TOptions options)
+    {
+        // Everything is fine, just return value
+        if (string.IsNullOrWhiteSpace(_name) is false
+            && _name.Equals(name) is false)
+            return ValidateOptionsResult.Skip;
+
+        ArgumentNullException.ThrowIfNull(options);
+
+        using var scope = _serviceProvider.CreateAsyncScope();
+        var validator = scope.ServiceProvider.GetRequiredService<IValidator<TOptions>>();
+
+        var results = validator.Validate(options);
+
+        // Everything went fine
+        if (results.IsValid)
+            return ValidateOptionsResult.Success;
+
+        var typeName = options.GetType().Name;
+        var errors = new List<string>();
+
+        foreach (var r in results.Errors)
+        {
+            errors.Add($"Validation error: '{typeName}.{r.PropertyName}' "
+                + $"with errors: '{r.ErrorCode}'");
+        }
+
+        return ValidateOptionsResult.Fail(errors);
+    }
+}

--- a/src/Backend/Backend.Api/Settings/SettingsValidationExtensions.cs
+++ b/src/Backend/Backend.Api/Settings/SettingsValidationExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Options;
+
+namespace Wotan.Backend.Api.Settings;
+
+internal static class SettingsValidationExtensions
+{
+    public static OptionsBuilder<TOptions> ValidateAPISettings<TOptions>(
+        this OptionsBuilder<TOptions> optionsBuilder)
+        where TOptions : class
+    {
+        optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(
+            provider => new FluentValidationOptions<TOptions>(
+                name: optionsBuilder.Name,
+                serviceProvider: provider));
+
+        return optionsBuilder;
+    }
+}


### PR DESCRIPTION
This includes handling configuration and validation of such. Setting up initial auto registration for generated code (ex: see ModuleInfo.cs).

These changes also includes reduction of startup tasks, meaning: it will always start both http and https ports but will redirect all requests to https by it self.

Updated pipeline to include schema generation test, as in: making sure GraphQL server is able to generate a valid schema with current setup or not (should prevent future breaking changes regarding available types and generated schema).